### PR TITLE
Version call added

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "griml"
-version = "1.0.0"
+version = "1.1.0"
 description = "A workflow for classifying ice-marginal lakes from satellite imagery and compiling lake inventories"
 readme = "README.md"
 authors = [{name = "Penelope How", email = "pho@geus.dk"}]

--- a/src/griml/__init__.py
+++ b/src/griml/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from importlib.metadata import version
+except ImportError:  # For Python <3.8 compatibility
+    from importlib_metadata import version
+
+__version__ = version("griml")  # Replace with your actual package name


### PR DESCRIPTION
GrIML package version can now be called like so (#26) :

```
import griml
griml.__version__`
```

I have also bumped the version up to v1.1.0 ready for a new release. 